### PR TITLE
Change the Interaction to PASS instead of FAIL

### DIFF
--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -10,7 +10,7 @@ plugins {
 repositories {
     maven {
         name = "Ladysnake Mods"
-        url = 'https://ladysnake.jfrog.io/artifactory/mods'
+        url = 'https://maven.ladysnake.org/releases'
     }
 }
 archivesBaseName = "${mod_name}-fabric-${minecraft_version}"

--- a/Fabric/src/main/java/jackdaw/fatchicken/events/FeedAnimalsEvent.java
+++ b/Fabric/src/main/java/jackdaw/fatchicken/events/FeedAnimalsEvent.java
@@ -43,7 +43,7 @@ public class FeedAnimalsEvent {
                     return InteractionResult.SUCCESS;
                 }
             }
-            return InteractionResult.FAIL;
+            return InteractionResult.PASS;
         });
     }
 }


### PR DESCRIPTION
Closes #7 

Changes the interaction to PASS so that other listeners can execute. Also changes the maven for Ladysnake Mods as JFrog no longer exists.